### PR TITLE
Update Cargo.toml

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -11,7 +11,7 @@ keywords = ["taskbar", "interfaces", "ui"]
 categories = ["gui"]
 
 [dependencies]
-raw-window-handle = "0"
+raw-window-handle = "0.5"
 
 [target.'cfg(all(unix, not(target_os="macos")))'.dependencies]
 lazy_static = "1"


### PR DESCRIPTION
Mentioning "0" would mean cargo would pick the latest dependency which is versioned "0.*" which would include versions incompatible with the one that this crate was written with and may break your create.